### PR TITLE
Loan History and All Specimens pages refined

### DIFF
--- a/code/TagAndTrack/TagAndTrack/Components/DataTableTemplate.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/DataTableTemplate.cs
@@ -22,6 +22,7 @@ namespace TagAndTrack.Components
             RowSpacing = 1;
             ColumnSpacing = 1;
             BackgroundColor = CurrentTheme.Instance.Theme.Background;
+            HorizontalOptions = LayoutOptions.Center;
 
             string[] headers = headerString.Split(new[] { ',' });
             string[] rows = csvString.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);

--- a/code/TagAndTrack/TagAndTrack/Components/EntryTemplate.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/EntryTemplate.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TagAndTrack.Components
+{
+    /// <summary>
+    /// Creates a entry/search bar component.
+    /// </summary>
+    internal class EntryTemplate : Grid
+    {
+        /// <summary>
+        /// The textbox used in the template.
+        /// </summary>
+        public TextboxTemplate textbox;
+
+        /// <summary>
+        /// The button used in the template.
+        /// </summary>
+        public Button button;
+
+        // TODO: implement a command and make sure to take that into the constructor as well.
+        /// <summary>
+        /// Creates a new instance of the <see cref="EntryTemplate"/> class.
+        /// </summary>
+        /// <param name="width">The width of the textbox.</param>
+        /// <param name="buttonText">The text for the button.</param>
+        public EntryTemplate(double width, string buttonText)
+        {
+            HorizontalOptions = LayoutOptions.Center;
+            ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+            ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+            Margin = new Thickness(10, 5);
+            textbox = new TextboxTemplate(width);
+            button = new Button
+            {
+                Text = buttonText,
+                BackgroundColor = Colors.Gray
+                // No search functionality yet.
+            };
+            this.Add(textbox, 0, 0);
+            this.Add(button, 1, 0);
+        }
+    }
+}

--- a/code/TagAndTrack/TagAndTrack/Components/TagAndTrackButton.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/TagAndTrackButton.cs
@@ -21,7 +21,7 @@ namespace TagAndTrack.Components
         /// <param name="command">The command to execute when the button is clicked.</param>
         public TagAndTrackButton(string text, Command command)
         {
-            Spacing = 6;
+            Spacing = 5;
             HorizontalOptions = LayoutOptions.Center;
             ButtonTemplate button = new ButtonTemplate()
             { 

--- a/code/TagAndTrack/TagAndTrack/Components/TextboxTemplate.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/TextboxTemplate.cs
@@ -9,29 +9,42 @@ namespace TagAndTrack.Components
     /// <summary>
     /// The template for the textboxes the app will use.
     /// </summary>
-    internal class TextboxTemplate : Entry
+    internal class TextboxTemplate : Border
     {
-        private CurrentTheme theme = new CurrentTheme();
+        /// <summary>
+        /// The textbox used in the template.
+        /// </summary>
+        public Entry textbox = new Entry();
 
         /// <summary>
         /// Creates a new instance of the <see cref="ButtonTemplate"/> class.
         /// </summary>
         public TextboxTemplate(double width)
         {
-            WidthRequest = width;
-            HeightRequest = 40;
-            BackgroundColor = CurrentTheme.Instance.Theme.Background;
-            TextColor = CurrentTheme.Instance.Theme.Text;
-            ClearButtonVisibility = ClearButtonVisibility.WhileEditing;
+            textbox.WidthRequest = width;
+            this.WidthRequest = width + 5;
+            textbox.HeightRequest = 40;
+            this.HeightRequest = 45;
+            textbox.BackgroundColor = CurrentTheme.Instance.Theme.Background;
+            textbox.TextColor = CurrentTheme.Instance.Theme.Text;
+            textbox.ClearButtonVisibility = ClearButtonVisibility.WhileEditing;
+
+            this.Stroke = CurrentTheme.Instance.Theme.Borders;
+            this.StrokeThickness = 1;
+            this.BackgroundColor = Colors.Transparent;
+
 
             CurrentTheme.Instance.PropertyChanged += (s, e) =>
             {
                 if (e.PropertyName == nameof(CurrentTheme.Theme))
                 {
-                    BackgroundColor = CurrentTheme.Instance.Theme.Background;
-                    TextColor = CurrentTheme.Instance.Theme.Text;
+                    textbox.BackgroundColor = CurrentTheme.Instance.Theme.Background;
+                    textbox.TextColor = CurrentTheme.Instance.Theme.Text;
+                    this.Stroke = CurrentTheme.Instance.Theme.Borders;
                 }
             };
+
+            this.Content = textbox;
         }
     }
 }

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllSpecimensPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllSpecimensPage.cs
@@ -24,6 +24,7 @@ namespace TagAndTrack.Pages
             var dt = new DataTableTemplate(dtHeader, ItemManager.GetItemsOfType(Item.ItemType.Specimen));
 
             var header = new HeaderTemplate(titleText);
+            var searchbar = new EntryTemplate(300, "Search");
             Content = new ScrollView
             {
                 Orientation = ScrollOrientation.Vertical,
@@ -32,6 +33,7 @@ namespace TagAndTrack.Pages
                     Children =
                     {
                         header,
+                        searchbar,
                         dt
                     }
                 }

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoanHistoryPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoanHistoryPage.cs
@@ -24,6 +24,7 @@ namespace TagAndTrack.Pages
 
             var header = new HeaderTemplate(titleText);
 
+            var searchbar = new EntryTemplate(300, "Search");
 
             // Wrap the data table in a ScrollView so content is vertically scrollable
             Content = new ScrollView
@@ -34,7 +35,13 @@ namespace TagAndTrack.Pages
                     Children =
                     {
                         header,
-                        dt
+                        searchbar,
+                        new ScrollView
+                        {
+                            Orientation = ScrollOrientation.Horizontal,
+                            HorizontalScrollBarVisibility = ScrollBarVisibility.Always,
+                            Content = dt
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Hopefully these look more professional, been focusing on making the pages look nicer.
From what I have researched, it seems like the scrollbar may not be visible on ipad and will let horizontal scrolling happen anywhere in the table.
<img width="877" height="1014" alt="image" src="https://github.com/user-attachments/assets/fbe5f062-a5c0-40af-a3e0-6e858189a77c" />
<img width="876" height="1016" alt="image" src="https://github.com/user-attachments/assets/1e920c68-f547-420c-8cec-2c1a56ec68f9" />

(And how it looks in dark mode)
<img width="879" height="1019" alt="image" src="https://github.com/user-attachments/assets/041da09a-5ccf-4258-b3df-a7ed320a3d3a" />
