### PR TITLE
improvements

### DIFF
--- a/code/TagAndTrack/TagAndTrack.Tests/LoanItemTests.cs
+++ b/code/TagAndTrack/TagAndTrack.Tests/LoanItemTests.cs
@@ -30,7 +30,7 @@ public class LoanItemTests
     }
 
     [Fact]
-    public void Checkin_CascadesToSpecimens()
+    public void Checkin_SetsReturnDatesForAllSpecimens()
     {
         var loan = new LoanItem("Loan", "desc");
         var s1 = new SpecimenItem("A", "a", "desc a");
@@ -38,20 +38,153 @@ public class LoanItemTests
         loan.AddSpecimen(s1);
         loan.AddSpecimen(s2);
 
-        // Check everything out
         loan.Checkout();
-        s1.Checkout();
-        s2.Checkout();
 
-        Assert.False(s1.Status);
-        Assert.False(s2.Status);
-
-        // Check in the loan — should cascade
         loan.Checkin();
 
         Assert.True(loan.Status);
-        Assert.True(s1.Status);
-        Assert.True(s2.Status);
+        Assert.NotNull(loan.GetSpecimenReturnDate(s1.ID));
+        Assert.NotNull(loan.GetSpecimenReturnDate(s2.ID));
+    }
+
+    [Fact]
+    public void CheckinSpecimen_SetsReturnDate()
+    {
+        var loan = new LoanItem("Loan", "desc");
+        var s1 = new SpecimenItem("A", "a", "desc a");
+        loan.AddSpecimen(s1);
+        loan.Checkout();
+
+        var returnDate = new DateTime(2026, 4, 14, 10, 30, 0);
+        loan.CheckinSpecimen(s1.ID, returnDate);
+
+        Assert.Equal(returnDate, loan.GetSpecimenReturnDate(s1.ID));
+    }
+
+    [Fact]
+    public void CheckinSpecimen_WhenAllReturned_MarksLoanReturned()
+    {
+        var loan = new LoanItem("Loan", "desc");
+        var s1 = new SpecimenItem("A", "a", "desc a");
+        var s2 = new SpecimenItem("B", "b", "desc b");
+        loan.AddSpecimen(s1);
+        loan.AddSpecimen(s2);
+        loan.Checkout();
+
+        var now = DateTime.Now;
+        loan.CheckinSpecimen(s1.ID, now);
+        Assert.False(loan.Status); // not all returned yet
+
+        loan.CheckinSpecimen(s2.ID, now);
+        Assert.True(loan.Status); // all returned, loan auto-checked in
+    }
+
+    [Fact]
+    public void CheckinSpecimen_WhenSomeReturned_LoanStillActive()
+    {
+        var loan = new LoanItem("Loan", "desc");
+        var s1 = new SpecimenItem("A", "a", "desc a");
+        var s2 = new SpecimenItem("B", "b", "desc b");
+        var s3 = new SpecimenItem("C", "c", "desc c");
+        loan.AddSpecimen(s1);
+        loan.AddSpecimen(s2);
+        loan.AddSpecimen(s3);
+        loan.Checkout();
+
+        loan.CheckinSpecimen(s1.ID, DateTime.Now);
+
+        Assert.False(loan.Status);
+        Assert.NotNull(loan.GetSpecimenReturnDate(s1.ID));
+        Assert.Null(loan.GetSpecimenReturnDate(s2.ID));
+        Assert.Null(loan.GetSpecimenReturnDate(s3.ID));
+    }
+
+    [Fact]
+    public void CheckinLoan_SkipsAlreadyReturnedSpecimens()
+    {
+        var loan = new LoanItem("Loan", "desc");
+        var s1 = new SpecimenItem("A", "a", "desc a");
+        var s2 = new SpecimenItem("B", "b", "desc b");
+        loan.AddSpecimen(s1);
+        loan.AddSpecimen(s2);
+        loan.Checkout();
+
+        // Check in s1 first at an earlier time
+        var earlyDate = new DateTime(2026, 4, 10);
+        loan.CheckinSpecimen(s1.ID, earlyDate);
+
+        // Now check in entire loan at a later time
+        var lateDate = new DateTime(2026, 4, 14);
+        loan.Checkin(lateDate);
+
+        // s1 should keep its original date, s2 gets the later date
+        Assert.Equal(earlyDate, loan.GetSpecimenReturnDate(s1.ID));
+        Assert.Equal(lateDate, loan.GetSpecimenReturnDate(s2.ID));
+        Assert.True(loan.Status);
+    }
+
+    [Fact]
+    public void CheckinSpecimen_AlreadyReturned_DoesNotOverwrite()
+    {
+        var loan = new LoanItem("Loan", "desc");
+        var s1 = new SpecimenItem("A", "a", "desc a");
+        loan.AddSpecimen(s1);
+        loan.Checkout();
+
+        var firstDate = new DateTime(2026, 4, 10);
+        var secondDate = new DateTime(2026, 4, 14);
+        loan.CheckinSpecimen(s1.ID, firstDate);
+        loan.CheckinSpecimen(s1.ID, secondDate); // should be ignored
+
+        Assert.Equal(firstDate, loan.GetSpecimenReturnDate(s1.ID));
+    }
+
+    [Fact]
+    public void Scenario_ReusedSpecimen_NotDoubleCheckedIn()
+    {
+        // 1. Create Loan1 with specimens A, B, C
+        var loan1 = new LoanItem("Loan 1", "First loan");
+        var specimenA = new SpecimenItem("ARC-A", "Item A", "desc A");
+        var specimenB = new SpecimenItem("ARC-B", "Item B", "desc B");
+        var specimenC = new SpecimenItem("ARC-C", "Item C", "desc C");
+        loan1.AddSpecimen(specimenA);
+        loan1.AddSpecimen(specimenB);
+        loan1.AddSpecimen(specimenC);
+        loan1.Checkout();
+
+        // 2. Item A is returned — check it in on Loan1
+        var returnDateA = new DateTime(2026, 4, 10, 14, 0, 0);
+        loan1.CheckinSpecimen(specimenA.ID, returnDateA);
+
+        Assert.Equal(returnDateA, loan1.GetSpecimenReturnDate(specimenA.ID));
+        Assert.Null(loan1.GetSpecimenReturnDate(specimenB.ID));
+        Assert.Null(loan1.GetSpecimenReturnDate(specimenC.ID));
+        Assert.False(loan1.Status); // loan not fully returned
+
+        // 3. Create Loan2 with specimens A, Y, Z (A re-loaned)
+        var loan2 = new LoanItem("Loan 2", "Second loan");
+        var specimenY = new SpecimenItem("ARC-Y", "Item Y", "desc Y");
+        var specimenZ = new SpecimenItem("ARC-Z", "Item Z", "desc Z");
+        loan2.AddSpecimen(specimenA);
+        loan2.AddSpecimen(specimenY);
+        loan2.AddSpecimen(specimenZ);
+        loan2.Checkout();
+
+        // 4. Items B and C are returned — user checks in Loan1 entirely
+        var loanCheckinDate = new DateTime(2026, 4, 14, 9, 0, 0);
+        loan1.Checkin(loanCheckinDate);
+
+        // Assertions for Loan1:
+        Assert.True(loan1.Status); // fully returned
+        Assert.Equal(returnDateA, loan1.GetSpecimenReturnDate(specimenA.ID)); // A keeps ORIGINAL date
+        Assert.Equal(loanCheckinDate, loan1.GetSpecimenReturnDate(specimenB.ID)); // B gets bulk date
+        Assert.Equal(loanCheckinDate, loan1.GetSpecimenReturnDate(specimenC.ID)); // C gets bulk date
+
+        // Assertions for Loan2: should be completely unaffected
+        Assert.False(loan2.Status); // still active
+        Assert.Null(loan2.GetSpecimenReturnDate(specimenA.ID)); // A not returned for Loan2
+        Assert.Null(loan2.GetSpecimenReturnDate(specimenY.ID));
+        Assert.Null(loan2.GetSpecimenReturnDate(specimenZ.ID));
     }
 
     [Fact]

--- a/code/TagAndTrack/TagAndTrack/App.xaml.cs
+++ b/code/TagAndTrack/TagAndTrack/App.xaml.cs
@@ -9,13 +9,13 @@ namespace TagAndTrack
         {
             InitializeComponent();
 
-            // Initialize logger FIRST so we can track everything
+            // Awaken the logger ere all else, that we may chronicle every happening
             DebugLogger.Init();
             DebugLogger.Log("=== APP CONSTRUCTOR STARTED ===");
 
             try
             {
-                // Initialize database synchronously at startup
+                // Summon the database in lockstep upon the hour of awakening
                 DebugLogger.Log("Starting database initialization...");
                 Task.Run(async () =>
                 {

--- a/code/TagAndTrack/TagAndTrack/AppShell.xaml.cs
+++ b/code/TagAndTrack/TagAndTrack/AppShell.xaml.cs
@@ -10,8 +10,8 @@ namespace TagAndTrack
             Routing.RegisterRoute("AllContainersPage", typeof(AllContainersPage));
             Routing.RegisterRoute("ViewContainerPage", typeof(ViewContainerPage));
 
-            // Add main page to shell structure so that it can be navigated to with "//MainPage" route.
-            // This allows the navigation stack to be cleared if navigating to MainPage.
+            // Bestow the main page unto the shell's dominion, that it may be reached by the "//MainPage" route.
+            // Thus shall the navigation stack be swept clean when one journeys unto MainPage.
             Items.Add(new ShellContent
             {
                 Route = "MainPage",

--- a/code/TagAndTrack/TagAndTrack/Backend/Data/DbService.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Data/DbService.cs
@@ -38,7 +38,7 @@ namespace TagAndTrack.Backend.Data
             DebugLogger.Log($"DbService: Database initialized successfully at {dbPath}");
         }
 
-        // ===== SPECIMENS =====
+        // ===== THE SPECIMENS =====
         public static async Task<List<SpecimenItem>> GetAllSpecimensAsync()
         {
             var entities = await _db!.Table<SpecimenEntity>().ToListAsync();
@@ -88,10 +88,10 @@ namespace TagAndTrack.Backend.Data
 
         public static async Task DeleteSpecimenAsync(int specimenId)
         {
-            // Remove from specimen table
+            // Expunge from the specimen table
             await _db!.DeleteAsync<SpecimenEntity>(specimenId);
 
-            // Remove from any container references
+            // Strike from any container that doth reference it
             var containers = await _db!.Table<ContainerEntity>().ToListAsync();
             foreach (var c in containers)
             {
@@ -117,7 +117,7 @@ namespace TagAndTrack.Backend.Data
             return s;
         }
 
-        // ===== LOANS =====
+        // ===== THE LOANS =====
         public static async Task<List<LoanItem>> GetAllLoansAsync()
         {
             var entities = await _db!.Table<LoanEntity>().ToListAsync();
@@ -153,7 +153,7 @@ namespace TagAndTrack.Backend.Data
             };
             await _db!.InsertAsync(entity);
 
-            // Insert join rows for each specimen
+            // Inscribe joining rows for each specimen
             foreach (var specimen in loan.Specimens)
             {
                 var returnDate = loan.GetSpecimenReturnDate(specimen.ID);
@@ -211,7 +211,7 @@ namespace TagAndTrack.Backend.Data
             loan.SetDates(e.DateCheckedOut, e.DateDue);
             loan.SetSignature(e.SignatureData);
 
-            // Load specimens and return dates from join table
+            // Gather the specimens and their dates of return from the joining table
             var joinRows = await _db!.Table<LoanSpecimenEntity>()
                 .Where(ls => ls.LoanId == e.Id)
                 .ToListAsync();
@@ -229,7 +229,7 @@ namespace TagAndTrack.Backend.Data
             return loan;
         }
 
-        // ===== CONTAINERS =====
+        // ===== THE CONTAINERS =====
         public static async Task<List<ContainerItem>> GetAllContainersAsync()
         {
             var entities = await _db!.Table<ContainerEntity>().ToListAsync();
@@ -306,7 +306,7 @@ namespace TagAndTrack.Backend.Data
             return result;
         }
 
-        // ===== LOANS (by specimen) =====
+        // ===== LOANS, SOUGHT BY SPECIMEN =====
         public static async Task<List<LoanItem>> GetLoansBySpecimenIdAsync(int specimenId)
         {
             var joinRows = await _db!.Table<LoanSpecimenEntity>()
@@ -325,7 +325,7 @@ namespace TagAndTrack.Backend.Data
             return result;
         }
 
-        // ===== EMPLOYEES =====
+        // ===== THE EMPLOYEES =====
         public static async Task<List<Employee>> GetAllEmployeesAsync()
         {
             DebugLogger.Log("DbService.GetAllEmployeesAsync() called");

--- a/code/TagAndTrack/TagAndTrack/Backend/Data/DbService.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Data/DbService.cs
@@ -31,6 +31,8 @@ namespace TagAndTrack.Backend.Data
             await _db.CreateTableAsync<ContainerEntity>();
             DebugLogger.Log("DbService: Creating EmployeeEntity table...");
             await _db.CreateTableAsync<EmployeeEntity>();
+            DebugLogger.Log("DbService: Creating LoanSpecimenEntity table...");
+            await _db.CreateTableAsync<LoanSpecimenEntity>();
 
             _initialized = true;
             DebugLogger.Log($"DbService: Database initialized successfully at {dbPath}");
@@ -60,6 +62,12 @@ namespace TagAndTrack.Backend.Data
             };
             await _db!.InsertAsync(entity);
             return entity.Id;
+        }
+
+        public static async Task<bool> ArctosIdExistsAsync(string arctosId)
+        {
+            var existing = await _db!.Table<SpecimenEntity>().FirstOrDefaultAsync(x => x.ArctosId == arctosId);
+            return existing != null;
         }
 
         public static async Task UpdateSpecimenAsync(int id, bool isPresent)
@@ -144,6 +152,19 @@ namespace TagAndTrack.Backend.Data
                 SignatureData = loan.SignatureImageBytes
             };
             await _db!.InsertAsync(entity);
+
+            // Insert join rows for each specimen
+            foreach (var specimen in loan.Specimens)
+            {
+                var returnDate = loan.GetSpecimenReturnDate(specimen.ID);
+                await _db!.InsertAsync(new LoanSpecimenEntity
+                {
+                    LoanId = entity.Id,
+                    SpecimenId = (int)specimen.ID,
+                    ReturnDate = returnDate
+                });
+            }
+
             return entity.Id;
         }
 
@@ -157,6 +178,28 @@ namespace TagAndTrack.Backend.Data
             }
         }
 
+        public static async Task CheckInLoanSpecimenAsync(int loanId, int specimenId, DateTime returnDate)
+        {
+            var joinRow = await _db!.Table<LoanSpecimenEntity>()
+                .FirstOrDefaultAsync(x => x.LoanId == loanId && x.SpecimenId == specimenId);
+            if (joinRow != null)
+            {
+                joinRow.ReturnDate = returnDate;
+                await _db!.UpdateAsync(joinRow);
+            }
+        }
+
+        public static async Task<bool> IsSpecimenInAnyActiveLoanAsync(int specimenId, int excludeLoanId)
+        {
+            var joinRows = await _db!.Table<LoanSpecimenEntity>()
+                .Where(x => x.SpecimenId == specimenId && x.ReturnDate == null)
+                .ToListAsync();
+            return joinRows.Any(x => x.LoanId != excludeLoanId);
+        }
+
+        public static async Task<List<LoanSpecimenEntity>> GetAllLoanSpecimenEntitiesAsync()
+            => await _db!.Table<LoanSpecimenEntity>().ToListAsync();
+
         private static async Task<LoanItem> MapToLoanAsync(LoanEntity e)
         {
             var loan = new LoanItem(e.Name, e.Description);
@@ -168,19 +211,21 @@ namespace TagAndTrack.Backend.Data
             loan.SetDates(e.DateCheckedOut, e.DateDue);
             loan.SetSignature(e.SignatureData);
 
-            // Load specimens
-            if (!string.IsNullOrEmpty(e.SpecimenIds))
+            // Load specimens and return dates from join table
+            var joinRows = await _db!.Table<LoanSpecimenEntity>()
+                .Where(ls => ls.LoanId == e.Id)
+                .ToListAsync();
+
+            foreach (var joinRow in joinRows)
             {
-                var ids = e.SpecimenIds.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                foreach (var idStr in ids)
+                var specimen = await GetSpecimenByIdAsync(joinRow.SpecimenId);
+                if (specimen != null)
                 {
-                    if (int.TryParse(idStr, out int specId))
-                    {
-                        var specimen = await GetSpecimenByIdAsync(specId);
-                        if (specimen != null) loan.AddSpecimen(specimen);
-                    }
+                    loan.AddSpecimen(specimen);
+                    loan.SetSpecimenReturnDate(specimen.ID, joinRow.ReturnDate);
                 }
             }
+
             return loan;
         }
 
@@ -264,15 +309,19 @@ namespace TagAndTrack.Backend.Data
         // ===== LOANS (by specimen) =====
         public static async Task<List<LoanItem>> GetLoansBySpecimenIdAsync(int specimenId)
         {
-            var entities = await _db!.Table<LoanEntity>().ToListAsync();
+            var joinRows = await _db!.Table<LoanSpecimenEntity>()
+                .Where(ls => ls.SpecimenId == specimenId)
+                .ToListAsync();
+
             var result = new List<LoanItem>();
-            foreach (var e in entities)
+            var loanIds = joinRows.Select(j => j.LoanId).Distinct();
+            foreach (var loanId in loanIds)
             {
-                if (SpecimenIdHelper.ContainsSpecimenId(e.SpecimenIds, specimenId))
-                {
-                    result.Add(await MapToLoanAsync(e));
-                }
+                var entity = await _db!.Table<LoanEntity>().FirstOrDefaultAsync(x => x.Id == loanId);
+                if (entity != null)
+                    result.Add(await MapToLoanAsync(entity));
             }
+
             return result;
         }
 
@@ -390,6 +439,18 @@ namespace TagAndTrack.Backend.Data
                     SpecimenIds = string.Join(",", specimenIds)
                 };
                 await _db.InsertAsync(loan);
+
+                // Insert join rows for each specimen in this loan
+                foreach (var specId in specimenIds)
+                {
+                    var loanSpecimen = new LoanSpecimenEntity
+                    {
+                        LoanId = loan.Id,
+                        SpecimenId = specId,
+                        ReturnDate = (i >= 8) ? DateTime.Now.AddDays(-5) : null // returned loans get a return date
+                    };
+                    await _db.InsertAsync(loanSpecimen);
+                }
             }
             DebugLogger.Log("DbService: 10 loans inserted");
 
@@ -436,6 +497,7 @@ namespace TagAndTrack.Backend.Data
 
             await _db!.DropTableAsync<SpecimenEntity>();
             await _db!.DropTableAsync<LoanEntity>();
+            await _db!.DropTableAsync<LoanSpecimenEntity>();
             await _db!.DropTableAsync<ContainerEntity>();
             await _db!.DropTableAsync<EmployeeEntity>();
 
@@ -443,6 +505,7 @@ namespace TagAndTrack.Backend.Data
 
             await _db!.CreateTableAsync<SpecimenEntity>();
             await _db!.CreateTableAsync<LoanEntity>();
+            await _db!.CreateTableAsync<LoanSpecimenEntity>();
             await _db!.CreateTableAsync<ContainerEntity>();
             await _db!.CreateTableAsync<EmployeeEntity>();
 

--- a/code/TagAndTrack/TagAndTrack/Backend/Data/Entities/LoanSpecimenEntity.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Data/Entities/LoanSpecimenEntity.cs
@@ -1,0 +1,14 @@
+using SQLite;
+
+namespace TagAndTrack.Backend.Data.Entities
+{
+    [Table("LoanSpecimens")]
+    public class LoanSpecimenEntity
+    {
+        [PrimaryKey, AutoIncrement]
+        public int Id { get; set; }
+        public int LoanId { get; set; }
+        public int SpecimenId { get; set; }
+        public DateTime? ReturnDate { get; set; }
+    }
+}

--- a/code/TagAndTrack/TagAndTrack/Backend/DebugLogger.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/DebugLogger.cs
@@ -14,7 +14,7 @@ namespace TagAndTrack.Backend
         {
             try
             {
-                // Clear the existing log file (or create if missing)
+                // Purge the existing log parchment, or bring one into being should none exist
                 File.WriteAllText(logFilePath, $"=== Log initialized at {DateTime.Now} ==={Environment.NewLine}");
             }
             catch (Exception ex)

--- a/code/TagAndTrack/TagAndTrack/Backend/Items/ItemManager.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Items/ItemManager.cs
@@ -47,27 +47,5 @@ namespace TagAndTrack.Backend.Items
                 _ => new List<Item>()
             };
         }
-
-        /// <summary>
-        /// Adds an item to the database.
-        /// </summary>
-        public static void AddItem(Item item)
-        {
-            Task.Run(async () =>
-            {
-                switch (item)
-                {
-                    case SpecimenItem specimen:
-                        await DbService.AddSpecimenAsync(specimen);
-                        break;
-                    case LoanItem loan:
-                        await DbService.AddLoanAsync(loan);
-                        break;
-                    case ContainerItem container:
-                        await DbService.AddContainerAsync(container);
-                        break;
-                }
-            }).Wait();
-        }
     }
 }

--- a/code/TagAndTrack/TagAndTrack/Backend/Items/LoanItem.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Items/LoanItem.cs
@@ -26,6 +26,10 @@
         public IReadOnlyList<SpecimenItem> Specimens => specimens;
         private readonly List<SpecimenItem> specimens = new();
 
+        // per-specimen return dates: specimen ID → return date (null = still on loan)
+        private readonly Dictionary<ulong, DateTime?> specimenReturnDates = new();
+        public IReadOnlyDictionary<ulong, DateTime?> SpecimenReturnDates => specimenReturnDates;
+
         // internal setters used by loader
         internal void SetBorrower(string? borrower) => Borrower = borrower;
         internal void SetEmail(string? email) => Email = email;
@@ -34,17 +38,69 @@
             DateCheckedOut = outDate;
             DateDue = dueDate;
         }
-        internal void AddSpecimen(SpecimenItem s) => specimens.Add(s);
+        internal void AddSpecimen(SpecimenItem s)
+        {
+            specimens.Add(s);
+            if (!specimenReturnDates.ContainsKey(s.ID))
+                specimenReturnDates[s.ID] = null;
+        }
         internal void SetSignature(byte[]? data) => SignatureImageBytes = data;
+        internal void SetSpecimenReturnDate(ulong specimenId, DateTime? date) => specimenReturnDates[specimenId] = date;
 
+        /// <summary>
+        /// Gets the return date for a specimen in this loan, or null if not yet returned.
+        /// </summary>
+        public DateTime? GetSpecimenReturnDate(ulong specimenId)
+        {
+            return specimenReturnDates.TryGetValue(specimenId, out var date) ? date : null;
+        }
+
+        /// <summary>
+        /// Checks in a single specimen for this loan. If all specimens are now returned,
+        /// the loan itself is marked as returned.
+        /// </summary>
+        public void CheckinSpecimen(ulong specimenId, DateTime returnDate)
+        {
+            if (!specimenReturnDates.ContainsKey(specimenId)) return;
+            if (specimenReturnDates[specimenId] != null) return; // already returned for this loan
+
+            specimenReturnDates[specimenId] = returnDate;
+
+            // Check if all specimens are now returned
+            if (specimenReturnDates.Values.All(d => d != null))
+            {
+                base.Checkin();
+            }
+        }
+
+        /// <summary>
+        /// Checks in all specimens that haven't been returned yet (for this loan).
+        /// Each gets the same return timestamp. Skips specimens already returned.
+        /// </summary>
         public override void Checkin()
         {
-            base.Checkin();
-
-            foreach (var item in Specimens)
+            var now = DateTime.Now;
+            foreach (var specimenId in specimenReturnDates.Keys.ToList())
             {
-                item.Checkin();
+                if (specimenReturnDates[specimenId] == null)
+                    specimenReturnDates[specimenId] = now;
             }
+
+            base.Checkin();
+        }
+
+        /// <summary>
+        /// Overload that accepts a specific timestamp for all remaining check-ins.
+        /// </summary>
+        public void Checkin(DateTime returnDate)
+        {
+            foreach (var specimenId in specimenReturnDates.Keys.ToList())
+            {
+                if (specimenReturnDates[specimenId] == null)
+                    specimenReturnDates[specimenId] = returnDate;
+            }
+
+            base.Checkin();
         }
     }
 }

--- a/code/TagAndTrack/TagAndTrack/Backend/Utils/CsvService.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Utils/CsvService.cs
@@ -19,10 +19,11 @@ namespace TagAndTrack.Backend.Utils
 
             var specimens = await DbService.GetAllSpecimenEntitiesAsync();
             var loans = await DbService.GetAllLoanEntitiesAsync();
+            var loanSpecimens = await DbService.GetAllLoanSpecimenEntitiesAsync();
             var containers = await DbService.GetAllContainerEntitiesAsync();
             var employees = await DbService.GetAllEmployeeEntitiesAsync();
 
-            var content = BuildExportCsv(specimens, loans, containers, employees);
+            var content = BuildExportCsv(specimens, loans, loanSpecimens, containers, employees);
             await File.WriteAllTextAsync(filePath, content);
 
             return filePath;
@@ -31,6 +32,7 @@ namespace TagAndTrack.Backend.Utils
         internal static string BuildExportCsv(
             IEnumerable<SpecimenEntity> specimens,
             IEnumerable<LoanEntity> loans,
+            IEnumerable<LoanSpecimenEntity> loanSpecimens,
             IEnumerable<ContainerEntity> containers,
             IEnumerable<EmployeeEntity> employees)
         {
@@ -47,6 +49,14 @@ namespace TagAndTrack.Backend.Utils
             {
                 string sig = l.SignatureData != null ? Convert.ToBase64String(l.SignatureData) : "";
                 sb.AppendLine($"{l.Id},{CsvEscape(l.ArctosId)},{CsvEscape(l.Name)},{CsvEscape(l.Description)},{CsvEscape(l.Borrower)},{CsvEscape(l.Email)},{l.DateCheckedOut:O},{l.DateDue:O},{l.IsReturned},{CsvEscape(l.SpecimenIds)},{CsvEscape(sig)}");
+            }
+
+            sb.AppendLine("[LoanSpecimens]");
+            sb.AppendLine("Id,LoanId,SpecimenId,ReturnDate");
+            foreach (var ls in loanSpecimens)
+            {
+                string returnDate = ls.ReturnDate.HasValue ? ls.ReturnDate.Value.ToString("O") : "";
+                sb.AppendLine($"{ls.Id},{ls.LoanId},{ls.SpecimenId},{returnDate}");
             }
 
             sb.AppendLine("[Containers]");
@@ -78,6 +88,8 @@ namespace TagAndTrack.Backend.Utils
                 await ImportSpecimenLines(specLines);
             if (sections.TryGetValue("Loans", out var loanLines))
                 await ImportLoanLines(loanLines);
+            if (sections.TryGetValue("LoanSpecimens", out var loanSpecimenLines))
+                await ImportLoanSpecimenLines(loanSpecimenLines);
             if (sections.TryGetValue("Containers", out var containerLines))
                 await ImportContainerLines(containerLines);
             if (sections.TryGetValue("Employees", out var employeeLines))
@@ -124,6 +136,23 @@ namespace TagAndTrack.Backend.Utils
                     SignatureData = !string.IsNullOrEmpty(fields[10]) ? Convert.FromBase64String(fields[10]) : null
                 };
                 await DbService.InsertRawEntityAsync(entity);
+            }
+        }
+
+        private static async Task ImportLoanSpecimenLines(List<string> lines)
+        {
+            foreach (var line in lines.Skip(1)) // skip header
+            {
+                var fields = ParseCsvLine(line);
+                if (fields.Length < 4) continue;
+                var entity = new LoanSpecimenEntity
+                {
+                    LoanId = int.TryParse(fields[1], out int lid) ? lid : 0,
+                    SpecimenId = int.TryParse(fields[2], out int sid) ? sid : 0,
+                    ReturnDate = DateTime.TryParse(fields[3], out var rd) ? rd : null
+                };
+                if (entity.LoanId > 0 && entity.SpecimenId > 0)
+                    await DbService.InsertRawEntityAsync(entity);
             }
         }
 

--- a/code/TagAndTrack/TagAndTrack/Backend/Utils/CsvService.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Utils/CsvService.cs
@@ -6,7 +6,7 @@ namespace TagAndTrack.Backend.Utils
 {
     public static class CsvService
     {
-        // ===== EXPORT =====
+        // ===== THE GRAND EXPORT =====
 
         public static async Task<string> ExportDatabaseAsync()
         {
@@ -75,7 +75,7 @@ namespace TagAndTrack.Backend.Utils
             return sb.ToString();
         }
 
-        // ===== IMPORT =====
+        // ===== THE GRAND IMPORT =====
 
         public static async Task ImportDatabaseAsync(string filePath)
         {
@@ -187,7 +187,7 @@ namespace TagAndTrack.Backend.Utils
             }
         }
 
-        // ===== CSV HELPERS =====
+        // ===== FAITHFUL CSV HELPERS =====
 
         internal static string CsvEscape(string? value) => CsvHelper.Escape(value);
 

--- a/code/TagAndTrack/TagAndTrack/Backend/Utils/Emailer.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Utils/Emailer.cs
@@ -8,7 +8,7 @@ using SkiaSharp;
 namespace TagAndTrack.Backend.Utils
 {
     // responsible for sending emails to the user's email
-    public static class Emailer
+    public static class Emailer // Emailer? I hardly know her!
     {
         /// <summary>⁄
         /// Sends an HTML-formatted email. If signatureData is provided,
@@ -23,7 +23,7 @@ namespace TagAndTrack.Backend.Utils
 
                 const string fromEmail = "TagAndTrackWSU@gmail.com"; // must match the Gmail account the app password is for
                 // ⚠️ SET THIS BEFORE BUILDING — intentionally blank in git for security
-                const string appPassword = "";        // 16-char Google app password, no spaces
+                const string appPassword = "sskfzaigiiebeivl";        // 16-char Google app password, no spaces
 
                 var finalBody = body;
                 byte[]? signaturePng = null;

--- a/code/TagAndTrack/TagAndTrack/Backend/Utils/Emailer.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Utils/Emailer.cs
@@ -7,7 +7,7 @@ using SkiaSharp;
 
 namespace TagAndTrack.Backend.Utils
 {
-    // responsible for sending emails to the user's email
+    // Charged with the solemn duty of dispatching missives unto the recipient
     public static class Emailer // Emailer? I hardly know her!
     {
         /// <summary>⁄
@@ -22,14 +22,14 @@ namespace TagAndTrack.Backend.Utils
                 DebugLogger.Log($"attempting to send email to {email}");
 
                 const string fromEmail = "TagAndTrackWSU@gmail.com"; // must match the Gmail account the app password is for
-                // ⚠️ SET THIS BEFORE BUILDING — intentionally blank in git for security
-                const string appPassword = "sskfzaigiiebeivl";        // 16-char Google app password, no spaces
+                // ⚠️ SET THIS ERE THOU BUILD — left barren in git for the safeguarding of secrets
+                const string appPassword = "";        // 16-char Google app password, no spaces
 
                 var finalBody = body;
                 byte[]? signaturePng = null;
                 string? signatureContentId = null;
 
-                // Embed signature as CID-linked PNG in HTML
+                // Weave the signature into the HTML as a CID-linked PNG portrait
                 if (signatureData != null && signatureData.Length > 0)
                 {
                     signaturePng = StrokesToPng(signatureData);
@@ -75,7 +75,7 @@ namespace TagAndTrack.Backend.Utils
                         smtpClient.EnableSsl = true;
                         smtpClient.DeliveryMethod = SmtpDeliveryMethod.Network;
 
-                        // critical bits for Gmail auth
+                        // The vital particulars for Gmail's authentication
                         smtpClient.UseDefaultCredentials = false;
                         smtpClient.Credentials = new NetworkCredential(fromEmail, appPassword);
 
@@ -123,7 +123,7 @@ namespace TagAndTrack.Backend.Utils
                 var strokes = JsonSerializer.Deserialize<float[][][]>(json);
                 if (strokes == null || strokes.Length == 0) return null;
 
-                // Find bounding box
+                // Discover the bounding box that containeth all
                 float minX = float.MaxValue, minY = float.MaxValue;
                 float maxX = float.MinValue, maxY = float.MinValue;
                 var pointCount = 0;

--- a/code/TagAndTrack/TagAndTrack/Backend/Utils/LoanCreator.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Utils/LoanCreator.cs
@@ -61,7 +61,7 @@ namespace TagAndTrack.Backend.Utils
         {
             var loan = new LoanItem(loanName, loanDescription);
 
-            // add and checkout specimens – persist each checkout to the database
+            // Add and check out the specimens — inscribe each departure in the database
             foreach (var item in LoanItems)
             {
                 loan.AddSpecimen(item);
@@ -75,7 +75,7 @@ namespace TagAndTrack.Backend.Utils
             loan.DateDue = dueDate;
             loan.SetSignature(signatureBytes);
 
-            // Persist loan + join rows to database
+            // Commit the loan and its joining rows unto the database
             await DbService.AddLoanAsync(loan);
 
             return loan;

--- a/code/TagAndTrack/TagAndTrack/Backend/Utils/LoanCreator.cs
+++ b/code/TagAndTrack/TagAndTrack/Backend/Utils/LoanCreator.cs
@@ -75,7 +75,8 @@ namespace TagAndTrack.Backend.Utils
             loan.DateDue = dueDate;
             loan.SetSignature(signatureBytes);
 
-            ItemManager.AddItem(loan);
+            // Persist loan + join rows to database
+            await DbService.AddLoanAsync(loan);
 
             return loan;
         }

--- a/code/TagAndTrack/TagAndTrack/Components/DataTable/DataTable.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/DataTable/DataTable.cs
@@ -34,7 +34,7 @@ namespace TagAndTrack.Components
                 searchBar = new SearchBar
                 {
                     Placeholder = "Search...",
-                    BackgroundColor = Colors.Transparent,
+                    BackgroundColor = CurrentTheme.Instance.Theme.Background,
                     TextColor = CurrentTheme.Instance.Theme.Text
                 };
                 _searchHandler = (s, e) => ApplyFilter(e.NewTextValue);
@@ -157,7 +157,8 @@ namespace TagAndTrack.Components
                             var cb = new CheckBox
                             {
                                 HorizontalOptions = LayoutOptions.Center,
-                                VerticalOptions = LayoutOptions.Center
+                                VerticalOptions = LayoutOptions.Center,
+                                Color = Colors.Crimson
                             };
 
                             if (col.CheckboxInitialValue != null)
@@ -231,9 +232,10 @@ namespace TagAndTrack.Components
         {
             if (e.PropertyName == nameof(CurrentTheme.Theme))
             {
-                searchBar?.TextColor = CurrentTheme.Instance.Theme.Text;
-                searchBorder?.Stroke = CurrentTheme.Instance.Theme.Borders;
-                searchBorder?.BackgroundColor = CurrentTheme.Instance.Theme.Background;
+                if (searchBar != null) searchBar.BackgroundColor = CurrentTheme.Instance.Theme.Background;
+                if (searchBar != null) searchBar.TextColor = CurrentTheme.Instance.Theme.Text;
+                if (searchBorder != null) searchBorder.Stroke = CurrentTheme.Instance.Theme.Borders;
+                if (searchBorder != null) searchBorder.BackgroundColor = CurrentTheme.Instance.Theme.Background;
             }
         }
 

--- a/code/TagAndTrack/TagAndTrack/Components/DataTable/DataTable.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/DataTable/DataTable.cs
@@ -23,14 +23,14 @@ namespace TagAndTrack.Components
             _filteredItems = new ObservableCollection<T>(items);
             _showSearchBar = showSearchBar;
 
-            // Build columns
+            // Erect the columns
             var builder = new DataTableColumnBuilder<T>();
             config(builder);
             columns = builder.Columns;
 
             if (_showSearchBar)
             {
-                // Search bar
+                // The instrument of inquiry
                 searchBar = new SearchBar
                 {
                     Placeholder = "Search...",
@@ -50,11 +50,11 @@ namespace TagAndTrack.Components
                     Content = searchBar
                 };
 
-                // Theme updates
+                // Attend to the theme's transformations
                 CurrentTheme.Instance.PropertyChanged += ThemeChanged;
             }
 
-            // Header
+            // The header, crowning the table
             var header = new Grid
             {
                 BackgroundColor = Colors.LightGray,
@@ -79,7 +79,7 @@ namespace TagAndTrack.Components
                 }, i, 0);
             }
 
-            // Table
+            // The table itself, bearer of all records
             var table = new CollectionView
             {
                 ItemsSource = _filteredItems,
@@ -197,7 +197,7 @@ namespace TagAndTrack.Components
                 })
             };
 
-            // Layout
+            // The arrangement of all within
             int row = 0;
             var layout = new Grid();
 

--- a/code/TagAndTrack/TagAndTrack/Components/HomeButton.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/HomeButton.cs
@@ -19,7 +19,7 @@ namespace TagAndTrack.Components
         {
             WidthRequest = 70;
             HeightRequest = 70;
-            // Set the command to navigate to MainPage when clicked.
+            // Decree the command: upon being pressed, journey unto MainPage.
             Command = new Command(async() => await Shell.Current.GoToAsync("//MainPage"));
 
             Source = "building.png";

--- a/code/TagAndTrack/TagAndTrack/Components/ScanView.cs
+++ b/code/TagAndTrack/TagAndTrack/Components/ScanView.cs
@@ -1,4 +1,4 @@
-﻿// ScanView.cs
+﻿// ScanView, the keeper of the scanning eye
 using System;
 using System.Linq;
 using Microsoft.Maui.Controls;
@@ -20,7 +20,7 @@ namespace TagAndTrack.Components
     {
         public event EventHandler<ScanCapturedEventArgs>? ScanCaptured;
 
-        // Keep a reference so we can control it outside the ctor
+        // Retain a reference, that we might command it beyond the constructor's bounds
         private readonly CameraBarcodeReaderView _scanner;
         private Page? _parentPage;
 
@@ -54,14 +54,14 @@ namespace TagAndTrack.Components
         {
             base.OnParentSet();
 
-            // Unhook from old page if any
+            // Sever ties with the former page, if such a bond didst exist
             if (_parentPage != null)
             {
                 _parentPage.Appearing -= OnPageAppearing;
                 _parentPage.Disappearing -= OnPageDisappearing;
             }
 
-            // Find the new parent page
+            // Seek out the new parent page
             _parentPage = FindParentPage();
 
             if (_parentPage != null)
@@ -83,13 +83,13 @@ namespace TagAndTrack.Components
 
         private void OnPageAppearing(object? sender, EventArgs e)
         {
-            // Turn scanning back on when the page becomes visible
+            // Rouse the scanning forth anew when the page doth reveal itself
             _scanner.IsDetecting = true;
         }
 
         private void OnPageDisappearing(object? sender, EventArgs e)
         {
-            // Stop scanning when the page disappears or is popped
+            // Cease the scanning when the page doth vanish or is cast away
             _scanner.IsDetecting = false;
         }
     }

--- a/code/TagAndTrack/TagAndTrack/MainPage.xaml.cs
+++ b/code/TagAndTrack/TagAndTrack/MainPage.xaml.cs
@@ -39,7 +39,7 @@ namespace TagAndTrack
 
             CurrentTheme.Instance.PropertyChanged += themeChangedHandler;
 
-            // Build header with logged-in user info
+            // Construct the header bearing the name of the logged-in soul
             var employeeName = EmployeeManager.ActiveEmployee?.Name ?? "Unknown";
             var headerText = $"Home";
 
@@ -84,7 +84,7 @@ namespace TagAndTrack
                 Grid.SetColumn(buttons[i], col);
             }
 
-            // Welcome message
+            // A message of welcome
             var welcomeLabel = new Label
             {
                 Text = $"Logged in as: {employeeName}",

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/AddItemPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/AddItemPage.cs
@@ -100,7 +100,12 @@ namespace TagAndTrack.Pages
 
             var specimen = new SpecimenItem($"ARC-{id:D6}", specimenNameEntry.textbox.Text, specimenDescriptionEntry.textbox.Text);
 
-            //TO DO: Look into where we want to check for duplicate ARC ID's (they may need to keep this functionality)
+            if (await DbService.ArctosIdExistsAsync(specimen.ArctosID))
+            {
+                await Shell.Current.DisplayAlert("Error", "A specimen with this Arctos ID already exists.", "OK");
+                return;
+            }
+
             await DbService.AddSpecimenAsync(specimen);
 
             await Shell.Current.DisplayAlert("Success!", "Specimen added to database!", "OK");

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllContainersPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllContainersPage.cs
@@ -244,9 +244,10 @@ namespace TagAndTrack.Pages
             var viewButton = new Button
             {
                 Text = "View",
-                BackgroundColor = Colors.CornflowerBlue,
+                BackgroundColor = Colors.Crimson,
                 TextColor = Colors.White,
-                Padding = new Thickness(15, 8)
+                Padding = new Thickness(15, 8),
+                CornerRadius = 8
             };
             viewButton.Clicked += async (s, e) =>
             {

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllContainersPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllContainersPage.cs
@@ -40,7 +40,7 @@ namespace TagAndTrack.Pages
 
             var addButton = new TagAndTrackButton("Add Container", new Command(async () => await AddContainerAsync()), "plus.png");
 
-            // Loading indicator - shown initially
+            // The loading herald — displayed upon first arrival
             loadingIndicator = new ActivityIndicator
             {
                 IsRunning = true,
@@ -52,7 +52,7 @@ namespace TagAndTrack.Pages
                 WidthRequest = 50
             };
 
-            // Status label for empty state or errors
+            // A label to proclaim emptiness or misfortune
             statusLabel = new Label
             {
                 Text = "Loading containers...",
@@ -72,7 +72,7 @@ namespace TagAndTrack.Pages
             CurrentTheme.Instance.PropertyChanged += themeChangedHandler;
             themeChangeHandlers.Add(themeChangedHandler);
 
-            // CollectionView for containers - handles scrolling properly on all platforms
+            // A CollectionView for the containers — it governeth scrolling with grace upon all platforms
             containerCollection = new CollectionView
             {
                 ItemsSource = containers,
@@ -85,7 +85,7 @@ namespace TagAndTrack.Pages
                 Margin = new Thickness(20, 10)
             };
 
-            // Use Grid layout (same pattern as AllSpecimensPage which works)
+            // Employ the Grid arrangement, mirroring AllSpecimensPage whose ways have proven true
             var pageLayout = new Grid
             {
                 RowDefinitions =
@@ -97,7 +97,7 @@ namespace TagAndTrack.Pages
                 Padding = new Thickness(0)
             };
 
-            // Content area with loading indicator, status label, and collection
+            // The realm of content: the loading herald, the status proclamation, and the collection
             var contentArea = new Grid
             {
                 Children = { loadingIndicator, statusLabel, containerCollection }
@@ -135,7 +135,7 @@ namespace TagAndTrack.Pages
 
             try
             {
-                // Show loading state on UI thread
+                // Reveal the loading state upon the thread of the interface
                 MainThread.BeginInvokeOnMainThread(() =>
                 {
                     if (loadingIndicator != null) loadingIndicator.IsVisible = true;
@@ -149,11 +149,11 @@ namespace TagAndTrack.Pages
                     if (containerCollection != null) containerCollection.IsVisible = false;
                 });
 
-                // Fetch data from database
+                // Summon forth the data from the depths of the database
                 var containerList = await DbService.GetAllContainersAsync();
                 DebugLogger.Log($"AllContainersPage: Retrieved {containerList.Count} containers from DB");
 
-                // Update UI on main thread
+                // Refresh the visage upon the main thread
                 MainThread.BeginInvokeOnMainThread(() =>
                 {
                     containers.Clear();
@@ -335,7 +335,7 @@ namespace TagAndTrack.Pages
             themeChangeHandlers.Clear();
         }
 
-        // Converter to display specimen count
+        // A converter to render the tally of specimens
         private class SpecimenCountConverter : IValueConverter
         {
             public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllSpecimensPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllSpecimensPage.cs
@@ -70,6 +70,7 @@ namespace TagAndTrack.Pages
         {
             DebugLogger.Log("AllSpecimensPage.OnAppearing() called");
             base.OnAppearing();
+            _ = LoadSpecimensAsync();
         }
 
         private void ApplyStatusFilter(string filter)
@@ -89,7 +90,7 @@ namespace TagAndTrack.Pages
 
         private void UpdateFilterButtonStyles()
         {
-            var activeColor = Colors.CornflowerBlue;
+            var activeColor = Colors.Crimson;
             var inactiveColor = Colors.Gray;
 
             if (_allButton != null) _allButton.BackgroundColor = _currentFilter == "All" ? activeColor : inactiveColor;
@@ -120,9 +121,9 @@ namespace TagAndTrack.Pages
             }
 
             // Filter buttons
-            _allButton = new Button { Text = "All", TextColor = Colors.White, Padding = new Thickness(10, 5) };
-            _checkedInButton = new Button { Text = "Checked In", TextColor = Colors.White, Padding = new Thickness(10, 5) };
-            _checkedOutButton = new Button { Text = "Checked Out", TextColor = Colors.White, Padding = new Thickness(10, 5) };
+            _allButton = new Button { Text = "All", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Crimson, CornerRadius = 8 };
+            _checkedInButton = new Button { Text = "Checked In", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
+            _checkedOutButton = new Button { Text = "Checked Out", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
 
             _allButton.Clicked += (s, e) => ApplyStatusFilter("All");
             _checkedInButton.Clicked += (s, e) => ApplyStatusFilter("Checked In");

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllSpecimensPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/AllSpecimensPage.cs
@@ -120,7 +120,7 @@ namespace TagAndTrack.Pages
                 return;
             }
 
-            // Filter buttons
+            // Buttons for the art of filtering
             _allButton = new Button { Text = "All", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Crimson, CornerRadius = 8 };
             _checkedInButton = new Button { Text = "Checked In", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
             _checkedOutButton = new Button { Text = "Checked Out", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
@@ -138,7 +138,7 @@ namespace TagAndTrack.Pages
                 Children = { _allButton, _checkedInButton, _checkedOutButton }
             };
 
-            // Create a simple data table
+            // Fashion a modest table of data
             DebugLogger.Log($"AllSpecimensPage: Creating DataTableTemplate with {_allSpecimens.Count} specimens");
             _dataTable = new DataTable<SpecimenItem>(_allSpecimens, columns =>
             {

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/CheckInLoanPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/CheckInLoanPage.cs
@@ -17,11 +17,11 @@ namespace TagAndTrack.Pages
         {
             base.OnAppearing();
 
-            // subscribe/start scanning when visible
+            // Subscribe and set the scanning forth when this page doth appear
             if (scanView != null && !_listening)
             {
                 scanView.ScanCaptured += ScanCaptured;
-                // if your ScanView supports control flags:
+                // Should thy ScanView bear the banner of control flags:
                 // scanView.IsScanning = true;
                 _listening = true;
             }
@@ -31,11 +31,11 @@ namespace TagAndTrack.Pages
         {
             base.OnDisappearing();
 
-            // unsubscribe/stop scanning when hidden
+            // Unsubscribe and still the scanning when this page doth retreat from sight
             if (scanView != null && _listening)
             {
                 scanView.ScanCaptured -= ScanCaptured;
-                // if supported:
+                // If such be supported:
                 // scanView.IsScanning = false;
                 _listening = false;
             }

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoanHistoryPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoanHistoryPage.cs
@@ -36,8 +36,6 @@ namespace TagAndTrack.Pages
                 }
             };
             CurrentTheme.Instance.PropertyChanged += handler;
-
-            BuildContent();
         }
 
         private string GetLoanStatus(LoanItem loan)
@@ -64,7 +62,7 @@ namespace TagAndTrack.Pages
 
         private void UpdateFilterButtonStyles()
         {
-            var activeColor = Colors.CornflowerBlue;
+            var activeColor = Colors.Crimson;
             var inactiveColor = Colors.Gray;
 
             if (_allButton != null) _allButton.BackgroundColor = _currentFilter == "All" ? activeColor : inactiveColor;
@@ -83,10 +81,10 @@ namespace TagAndTrack.Pages
             }
 
             // Filter buttons
-            _allButton = new Button { Text = "All", TextColor = Colors.White, Padding = new Thickness(10, 5) };
-            _onLoanButton = new Button { Text = "On Loan", TextColor = Colors.White, Padding = new Thickness(10, 5) };
-            _overdueButton = new Button { Text = "Overdue", TextColor = Colors.White, Padding = new Thickness(10, 5) };
-            _checkedInButton = new Button { Text = "Checked In", TextColor = Colors.White, Padding = new Thickness(10, 5) };
+            _allButton = new Button { Text = "All", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Crimson, CornerRadius = 8 };
+            _onLoanButton = new Button { Text = "On Loan", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
+            _overdueButton = new Button { Text = "Overdue", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
+            _checkedInButton = new Button { Text = "Checked In", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
 
             _allButton.Clicked += (s, e) => ApplyStatusFilter("All");
             _onLoanButton.Clicked += (s, e) => ApplyStatusFilter("On Loan");

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoanHistoryPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoanHistoryPage.cs
@@ -80,7 +80,7 @@ namespace TagAndTrack.Pages
                 _allLoans.Add((LoanItem)item);
             }
 
-            // Filter buttons
+            // Buttons for the art of filtering
             _allButton = new Button { Text = "All", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Crimson, CornerRadius = 8 };
             _onLoanButton = new Button { Text = "On Loan", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };
             _overdueButton = new Button { Text = "Overdue", TextColor = Colors.White, Padding = new Thickness(10, 5), BackgroundColor = Colors.Gray, CornerRadius = 8 };

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoginPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/LoginPage.cs
@@ -52,7 +52,7 @@ namespace TagAndTrack.Pages
             _themeHandlers.Add(changeHandler);
             CurrentTheme.Instance.PropertyChanged += changeHandler;
 
-            // Employee picker - will be populated from DB
+            // The employee picker — to be filled from the database in due course
             employeePicker = new Picker
             {
                 Title = "-- Select Employee --",
@@ -63,7 +63,7 @@ namespace TagAndTrack.Pages
                 TitleColor = Colors.Gray,
                 BackgroundColor = CurrentTheme.Instance.Theme.Background
             };
-            // When user selects from dropdown, update the text entry to show selected name
+            // When the user chooseth from the dropdown, let the text entry mirror the chosen name
             EventHandler eventHandler = (s, e) =>
             {
                 if (employeePicker.SelectedIndex >= 0 && employeePicker.SelectedItem != null)
@@ -89,7 +89,7 @@ namespace TagAndTrack.Pages
             CurrentTheme.Instance.PropertyChanged += changeHandler;
             _themeHandlers.Add(changeHandler);
 
-            // Wrap picker in a border for visibility
+            // Encase the picker within a border, that it may be clearly seen
             var pickerBorder = new Border
             {
                 Stroke = Colors.Gray,
@@ -157,7 +157,7 @@ namespace TagAndTrack.Pages
                 }
             };
 
-            // Load employees from database
+            // Summon the employees from the database
             DebugLogger.Log("LoginPage.Initialize() calling LoadEmployeesAsync()");
             _ = LoadEmployeesAsync();
             DebugLogger.Log("LoginPage.Initialize() complete");
@@ -203,7 +203,7 @@ namespace TagAndTrack.Pages
                 string? name = newEmployeeEntry?.textbox?.Text?.Trim();
                 DebugLogger.Log($"Entry text value: '{name ?? "(null)"}'");
 
-                // Prefer typed name over picker selection
+                // Give precedence to a name inscribed by hand over one chosen from the picker
                 if (string.IsNullOrWhiteSpace(name) && employeePicker?.SelectedItem != null)
                 {
                     name = employeePicker.SelectedItem.ToString();
@@ -220,7 +220,7 @@ namespace TagAndTrack.Pages
                 DebugLogger.Log($"Looking for existing employee with name: '{name}'");
                 DebugLogger.Log($"Current employees list has {employees.Count} items");
 
-                // Check if employee exists
+                // Inquire whether this employee doth already exist
                 var existing = employees.FirstOrDefault(e => e.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
                 Employee employee;
 

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/ScanItemPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/ScanItemPage.cs
@@ -65,11 +65,11 @@ namespace TagAndTrack.Pages
         {
             base.OnAppearing();
 
-            // subscribe/start scanning when visible
+            // Subscribe and set the scanning forth when this page doth appear
             if (scanView != null && !_listening)
             {
                 scanView.ScanCaptured += ScanCaptured;
-                // if your ScanView supports control flags:
+                // Should thy ScanView bear the banner of control flags:
                 // scanView.IsScanning = true;
                 _listening = true;
             }
@@ -79,11 +79,11 @@ namespace TagAndTrack.Pages
         {
             base.OnDisappearing();
 
-            // unsubscribe/stop scanning when hidden
+            // Unsubscribe and still the scanning when this page doth retreat from sight
             if (scanView != null && _listening)
             {
                 scanView.ScanCaptured -= ScanCaptured;
-                // if supported:
+                // If such be supported:
                 // scanView.IsScanning = false;
                 _listening = false;
             }
@@ -108,7 +108,7 @@ namespace TagAndTrack.Pages
                 return;
             }
             
-            // stop scanning before navigation
+            // Halt the scanning ere we navigate hence
             OnDisappearing();
 
             ScannedQRItem.lastScannedItem = qr;

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/SettingsPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/SettingsPage.cs
@@ -50,7 +50,7 @@ namespace TagAndTrack.Pages
                 var exportFilePath = await CsvService.ExportDatabaseAsync();
 
 #if WINDOWS
-                // Windows: prompt user to pick a save location
+                // Upon Windows: beseech the user to choose a place of saving
                 var savePicker = new Windows.Storage.Pickers.FileSavePicker();
                 savePicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;
                 savePicker.FileTypeChoices.Add("CSV File", new List<string> { ".csv" });
@@ -65,7 +65,7 @@ namespace TagAndTrack.Pages
                 File.Copy(exportFilePath, file.Path, overwrite: true);
                 await DisplayAlert("Done", $"CSV saved to:\n{file.Path}", "OK");
 #else
-                // iOS/Mac: use Share sheet (has built-in Save to Files)
+                // Upon iOS or Mac: employ the Share sheet, which doth offer Save to Files
                 await Share.Default.RequestAsync(new ShareFileRequest
                 {
                     Title = "Export Tag & Track Database",
@@ -108,7 +108,7 @@ namespace TagAndTrack.Pages
 
                 if (result == null) return;
 
-                // Copy picked file to a temp location so CsvService can read it
+                // Copy the chosen file to a temporary dwelling, that CsvService might read it
                 var importPath = Path.Combine(FileSystem.CacheDirectory, "tagandtrack_import.csv");
                 using (var source = await result.OpenReadAsync())
                 using (var dest = File.Create(importPath))

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/StartLoanPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/StartLoanPage.cs
@@ -24,12 +24,12 @@ namespace TagAndTrack.Pages
         {
             base.OnAppearing();
 
-            // subscribe/start scanning when visible
+            // Subscribe and set the scanning forth when this page doth appear
             if (scanView != null && !_listening)
             {
                 scanView.ScanCaptured += ScanCaptured;
 
-                // if your ScanView supports control flags:
+                // Should thy ScanView bear the banner of control flags:
                 // scanView.IsScanning = true;
                 _listening = true;
             }
@@ -39,12 +39,12 @@ namespace TagAndTrack.Pages
         {
             base.OnDisappearing();
 
-            // unsubscribe/stop scanning when hidden
+            // Unsubscribe and still the scanning when this page doth retreat from sight
             if (scanView != null && _listening)
             {
                 scanView.ScanCaptured -= ScanCaptured;
 
-                // if supported:
+                // If such be supported:
                 // scanView.IsScanning = false;
                 _listening = false;
             }
@@ -69,7 +69,7 @@ namespace TagAndTrack.Pages
 
             var header = new HeaderTemplate(titleText);
 
-            // See if this change affects anything
+            // Observe whether this alteration doth bear any consequence
             scanView = new ScanView
             {
                 WidthRequest = 600,
@@ -100,7 +100,7 @@ namespace TagAndTrack.Pages
                 }
             };
 
-            // Scanner + buttons side-by-side so buttons stay visible in landscape
+            // The scanner and buttons, arrayed side by side, that the buttons remain visible upon a wider stage
             var scannerRow = new Grid
             {
                 ColumnDefinitions =
@@ -219,7 +219,7 @@ namespace TagAndTrack.Pages
         {
             var allSpecimens = await DbService.GetAllSpecimensAsync();
 
-            // Show all checked-in specimens; items already in loan will be pre-checked
+            // Present all checked-in specimens; those already bound to the loan shall be marked beforehand
             var existingIds = LoanCreator.LoanItems.Select(s => s.ID).ToHashSet();
             var available = allSpecimens.Where(s => s.Status || existingIds.Contains(s.ID)).ToList();
 
@@ -235,8 +235,8 @@ namespace TagAndTrack.Pages
 
             var selected = await tcs.Task;
 
-            // Sync loan items to match the final selection:
-            // remove unchecked items, add newly checked items
+            // Harmonize the loan's contents with the final selection:
+            // cast out the unchecked, welcome the newly chosen
             var selectedIds = selected.Select(s => s.ID).ToHashSet();
             var toRemove = LoanCreator.LoanItems.Where(s => !selectedIds.Contains(s.ID)).ToList();
             foreach (var specimen in toRemove)

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/TagAndTrackPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/TagAndTrackPage.cs
@@ -11,13 +11,5 @@ namespace TagAndTrack.Pages
 
         // Initialize sets up all content in the page and should be called in the page constructor.
         protected abstract void Initialize();
-
-        // Re-initialize page content whenever the page becomes visible,
-        // ensuring data is fresh after navigating back from another page.
-        protected override void OnAppearing()
-        {
-            base.OnAppearing();
-            Initialize();
-        }
     }
 }

--- a/code/TagAndTrack/TagAndTrack/Pages/MainPages/TagAndTrackPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/MainPages/TagAndTrackPage.cs
@@ -2,14 +2,14 @@ namespace TagAndTrack.Pages
 {
     public abstract class TagAndTrackPage : ContentPage
     {
-        // Should this page have the default navigation back button?
+        // Doth this page bear the customary navigation back button?
         public bool HasBackButton
         {
             get;
             private set;
         }
 
-        // Initialize sets up all content in the page and should be called in the page constructor.
+        // Initialize doth arrange all content upon the page and ought be summoned within the constructor.
         protected abstract void Initialize();
     }
 }

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/FinalizeLoanPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/FinalizeLoanPage.cs
@@ -79,12 +79,39 @@ namespace TagAndTrack.Pages.SupportPages
                 MinimumDate = DateTime.Today.AddDays(1),
                 Date = DateTime.Today.AddDays(30),
                 Format = "yyyy-MM-dd",
-                HorizontalOptions = LayoutOptions.Center,
-                Margin = new Thickness(24, 4, 24, 12),
+                HorizontalOptions = LayoutOptions.Fill,
                 TextColor = CurrentTheme.Instance.Theme.Text,
-                BackgroundColor = CurrentTheme.Instance.Theme.Background,
-                WidthRequest = 250,
+                BackgroundColor = Colors.Transparent,
                 HeightRequest = 40
+            };
+
+            var calendarIcon = new Label
+            {
+                Text = "📅",
+                FontSize = 24,
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Start
+            };
+
+            var datePickerRow = new HorizontalStackLayout
+            {
+                Spacing = 10,
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Center,
+                Children = { calendarIcon, dueDatePicker }
+            };
+
+            var datePickerBorder = new Border
+            {
+                Stroke = CurrentTheme.Instance.Theme.Borders,
+                StrokeThickness = 1,
+                StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = 8 },
+                Padding = new Thickness(12, 4),
+                Margin = new Thickness(24, 4, 24, 12),
+                HorizontalOptions = LayoutOptions.Center,
+                BackgroundColor = CurrentTheme.Instance.Theme.Background,
+                MinimumWidthRequest = 250,
+                Content = datePickerRow
             };
 
             themeChangedHandler = (s, e) =>
@@ -92,7 +119,8 @@ namespace TagAndTrack.Pages.SupportPages
                 if (e.PropertyName == nameof(CurrentTheme.Theme))
                 {
                     dueDatePicker.TextColor = CurrentTheme.Instance.Theme.Text;
-                    dueDatePicker.BackgroundColor = CurrentTheme.Instance.Theme.Background;
+                    datePickerBorder.Stroke = CurrentTheme.Instance.Theme.Borders;
+                    datePickerBorder.BackgroundColor = CurrentTheme.Instance.Theme.Background;
                 }
             };
 
@@ -143,10 +171,11 @@ namespace TagAndTrack.Pages.SupportPages
             var clearSignatureButton = new Button
             {
                 Text = "Clear Signature",
-                BackgroundColor = Colors.Gray,
+                BackgroundColor = Colors.Crimson,
                 TextColor = Colors.White,
                 HorizontalOptions = LayoutOptions.Center,
-                Margin = new Thickness(0, 4, 0, 12)
+                Margin = new Thickness(0, 4, 0, 12),
+                CornerRadius = 8
             };
             clearSignatureButton.Clicked += (s, e) => signaturePad.Clear();
 
@@ -185,7 +214,7 @@ namespace TagAndTrack.Pages.SupportPages
                         clientNameEntry,
                         clientEmailEntry,
                         dueDateLabel,
-                        dueDatePicker,
+                        datePickerBorder,
                         signatureLabel,
                         signatureBorder,
                         clearSignatureButton,

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/FinalizeLoanPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/FinalizeLoanPage.cs
@@ -28,7 +28,7 @@ namespace TagAndTrack.Pages.SupportPages
 
         protected override void Initialize()
         {
-            // Apply theme background and react to theme changes
+            // Don the theme's raiment and heed its every transformation
             Background = CurrentTheme.Instance.Theme.Background;
 
             PropertyChangedEventHandler themeChangedHandler = (s, e) =>
@@ -127,7 +127,7 @@ namespace TagAndTrack.Pages.SupportPages
             CurrentTheme.Instance.PropertyChanged += themeChangedHandler;
             themeChangeHandlers.Add(themeChangedHandler);
 
-            // Signature pad for borrower handwritten signature
+            // A pad whereupon the borrower may inscribe their mark by hand
             var signatureLabel = new Label
             {
                 Text = "Borrower Signature (sign below):",
@@ -265,7 +265,7 @@ namespace TagAndTrack.Pages.SupportPages
                 .Append("<th>Description</th>")
                 .Append("</tr>");
 
-            // Split rows by line breaks
+            // Cleave the rows asunder at each line's end
             var rows = csv.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var row in rows)
@@ -301,7 +301,7 @@ namespace TagAndTrack.Pages.SupportPages
                 return;
             }
 
-            // Capture signature as JSON stroke bytes (optional)
+            // Seize the signature as JSON stroke bytes, if Providence so wills
             byte[]? signatureBytes = null;
             try
             {
@@ -313,7 +313,7 @@ namespace TagAndTrack.Pages.SupportPages
                 await Shell.Current.DisplayAlertAsync("DEBUG: Signature Capture Error", ex.ToString(), "OK");
             }
 
-            // Build the email body BEFORE persisting to DB
+            // Compose the body of the missive ere committing aught unto the ledger
             var dueDate = dueDatePicker.Date ?? DateTime.Today.AddDays(30);
 
             var sb = new StringBuilder();
@@ -329,7 +329,7 @@ namespace TagAndTrack.Pages.SupportPages
             var htmlTable = CsvToHtmlTable(CreateDTCSV());
             var body = sb.ToString() + "<br>" + htmlTable;
 
-            // Send email FIRST — only finalize to DB on success
+            // Dispatch the missive first — only upon triumph shall we inscribe it in the ledger
             var (emailSuccess, emailError) = Emailer.Email(
                 clientEmailEntry.textbox.Text,
                 $"Tag and Track Loan Confirmed",
@@ -342,7 +342,7 @@ namespace TagAndTrack.Pages.SupportPages
                 return;
             }
 
-            // Email succeeded — now persist to DB
+            // The missive hath found its mark — now let us commit the record to the ledger
             var loan = await LoanCreator.FinalizeLoanAsync(
                 loanNameEntry.textbox.Text,
                 loanDescriptionEntry.textbox.Text,

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/SelectSpecimensPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/SelectSpecimensPage.cs
@@ -16,7 +16,7 @@ namespace TagAndTrack.Pages
             _tcs = tcs;
             _preSelectedIds = preSelectedIds != null ? new HashSet<ulong>(preSelectedIds) : new HashSet<ulong>();
 
-            // Seed _selected with pre-checked items
+            // Sow the _selected field with those items already chosen
             foreach (var s in _available)
             {
                 if (_preSelectedIds.Contains(s.ID))

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewContainerPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewContainerPage.cs
@@ -156,14 +156,18 @@ namespace TagAndTrack.Pages
                     }
 
                     // Update header - replace with new one showing container name
-                    if (_header != null && Content is ScrollView sv && sv.Content is VerticalStackLayout vsl)
+                    if (_header != null && Content is Grid pageGrid)
                     {
-                        var idx = vsl.Children.IndexOf(_header);
-                        if (idx >= 0)
+                        // topSection is the first child of the page grid
+                        if (pageGrid.Children[0] is VerticalStackLayout topSection)
                         {
-                            var newHeader = new HeaderTemplate(_container.Name ?? "Container");
-                            vsl.Children[idx] = newHeader;
-                            _header = newHeader;
+                            var idx = topSection.Children.IndexOf(_header);
+                            if (idx >= 0)
+                            {
+                                var newHeader = new HeaderTemplate(_container.Name ?? "Container");
+                                topSection.Children[idx] = newHeader;
+                                _header = newHeader;
+                            }
                         }
                     }
 

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewContainerPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewContainerPage.cs
@@ -10,7 +10,7 @@ namespace TagAndTrack.Pages
         private readonly int _containerId;
         private ContainerItem? _container;
 
-        // Persistent UI elements updated by LoadContainerAsync
+        // Enduring elements of the interface, shaped anew by LoadContainerAsync
         private HeaderTemplate? _header;
         private Label? _descriptionLabel;
         private QrCodeView? _qrCode;
@@ -145,20 +145,20 @@ namespace TagAndTrack.Pages
 
                 DebugLogger.Log($"ViewContainerPage: Building UI for container '{_container.Name}' with {_container.Specimens.Count} specimens");
 
-                // All UI updates on the main thread
+                // All changes to the visage must occur upon the main thread
                 MainThread.BeginInvokeOnMainThread(() =>
                 {
-                    // Hide loading, show content
+                    // Conceal the loading herald, reveal the content
                     if (_loadingIndicator != null)
                     {
                         _loadingIndicator.IsRunning = false;
                         _loadingIndicator.IsVisible = false;
                     }
 
-                    // Update header - replace with new one showing container name
+                    // Refresh the header — supplant it with one bearing the container's name
                     if (_header != null && Content is Grid pageGrid)
                     {
-                        // topSection is the first child of the page grid
+                        // The topSection doth sit as firstborn child of the page grid
                         if (pageGrid.Children[0] is VerticalStackLayout topSection)
                         {
                             var idx = topSection.Children.IndexOf(_header);
@@ -171,21 +171,21 @@ namespace TagAndTrack.Pages
                         }
                     }
 
-                    // Update description
+                    // Renew the description
                     if (_descriptionLabel != null)
                     {
                         _descriptionLabel.Text = _container.Description ?? "";
                         _descriptionLabel.IsVisible = true;
                     }
 
-                    // Update QR code
+                    // Renew the QR cipher
                     if (_qrCode != null)
                     {
                         _qrCode.Value = _container.QRID ?? "";
                         _qrCode.IsVisible = true;
                     }
 
-                    // Add button
+                    // Furnish the button
                     if (_addButtonContainer != null)
                     {
                         _addButtonContainer.Children.Clear();
@@ -195,7 +195,7 @@ namespace TagAndTrack.Pages
                         _addButtonContainer.IsVisible = true;
                     }
 
-                    // Specimens title
+                    // The title for the specimens
                     if (_specimensContainer != null)
                     {
                         _specimensContainer.Children.Clear();
@@ -286,10 +286,10 @@ namespace TagAndTrack.Pages
 
         private async Task AddSpecimenAsync()
         {
-            // Get all specimens from DB
+            // Retrieve every specimen from the great ledger
             var allSpecimens = await DbService.GetAllSpecimensAsync();
 
-            // Filter out specimens already in container
+            // Cast aside those specimens already dwelling within the container
             var existingIds = _container?.Specimens.Select(s => s.ID).ToHashSet() ?? new HashSet<ulong>();
             var available = allSpecimens.Where(s => !existingIds.Contains(s.ID)).ToList();
 

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewItemPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewItemPage.cs
@@ -357,6 +357,22 @@ namespace TagAndTrack.Pages
             {
                 columns.Add("ID", s => s.ID, 60);
                 columns.Add("Name", s => s.Name);
+                columns.Add("Return Date", s =>
+                {
+                    var returnDate = loan.GetSpecimenReturnDate(s.ID);
+                    return returnDate?.ToString("yyyy-MM-dd HH:mm") ?? "On Loan";
+                }, width: 140);
+
+                if (!loan.Status) // only show check-in buttons if loan is active
+                {
+                    columns.AddButton("Check In",
+                    s =>
+                    {
+                        if (loan.GetSpecimenReturnDate(s.ID) != null) return; // already returned
+                        _ = CheckInSpecimenAsync(s);
+                    },
+                    "check.png", 80);
+                }
 
                 columns.AddButton("View Specimen",
                 s =>
@@ -387,29 +403,77 @@ namespace TagAndTrack.Pages
             };
         }
 
-        private async Task CheckInLoan()
+        private async Task CheckInSpecimenAsync(SpecimenItem specimen)
         {
             if (loanItem == null) return;
-            
+            if (loanItem.GetSpecimenReturnDate(specimen.ID) != null) return; // already returned
+
+            var now = DateTime.Now;
+
             // Update in-memory state
-            loanItem.Checkin();
+            loanItem.CheckinSpecimen(specimen.ID, now);
 
-            // Persist loan to database (cast ulong ID to int for DB)
-            await DbService.UpdateLoanAsync((int)loanItem.ID, true);
+            // Persist return date to join table
+            await DbService.CheckInLoanSpecimenAsync((int)loanItem.ID, (int)specimen.ID, now);
 
-            // Persist all specimens to database
-            foreach (var specimen in loanItem.Specimens)
+            // Only mark specimen as present if it's not in any OTHER active loan
+            bool inOtherLoan = await DbService.IsSpecimenInAnyActiveLoanAsync((int)specimen.ID, (int)loanItem.ID);
+            if (!inOtherLoan)
             {
+                specimen.Checkin();
                 await DbService.UpdateSpecimenAsync((int)specimen.ID, true);
+            }
+
+            // If all specimens are now returned, mark loan as returned
+            if (loanItem.Status)
+            {
+                await DbService.UpdateLoanAsync((int)loanItem.ID, true);
             }
 
             await MainThread.InvokeOnMainThreadAsync(async () =>
             {
-                await Shell.Current.DisplayAlert("Loan Checked In", $"The loan and all its items have been checked in!", "OK");
+                string msg = loanItem.Status
+                    ? "All items returned — loan is now fully checked in!"
+                    : $"{specimen.Name} has been checked in.";
+                await Shell.Current.DisplayAlert("Specimen Checked In", msg, "OK");
             });
 
-                Initialize();
+            Initialize();
+        }
 
+        private async Task CheckInLoan()
+        {
+            if (loanItem == null) return;
+
+            var now = DateTime.Now;
+
+            // Check in each specimen that hasn't been returned yet for THIS loan
+            foreach (var specimen in loanItem.Specimens)
+            {
+                if (loanItem.GetSpecimenReturnDate(specimen.ID) != null)
+                    continue; // already returned for this loan — skip
+
+                loanItem.CheckinSpecimen(specimen.ID, now);
+                await DbService.CheckInLoanSpecimenAsync((int)loanItem.ID, (int)specimen.ID, now);
+
+                // Only mark specimen as present if not in another active loan
+                bool inOtherLoan = await DbService.IsSpecimenInAnyActiveLoanAsync((int)specimen.ID, (int)loanItem.ID);
+                if (!inOtherLoan)
+                {
+                    specimen.Checkin();
+                    await DbService.UpdateSpecimenAsync((int)specimen.ID, true);
+                }
+            }
+
+            // Mark loan as returned
+            await DbService.UpdateLoanAsync((int)loanItem.ID, true);
+
+            await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                await Shell.Current.DisplayAlert("Loan Checked In", "The loan and all its items have been checked in!", "OK");
+            });
+
+            Initialize();
         }
 
         private async Task DeleteSpecimenAsync(SpecimenItem specimen)

--- a/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewItemPage.cs
+++ b/code/TagAndTrack/TagAndTrack/Pages/SupportPages/ViewItemPage.cs
@@ -101,7 +101,7 @@ namespace TagAndTrack.Pages
             CurrentTheme.Instance.PropertyChanged += handler;
             themeChangeHandlers.Add(handler);
 
-            // Placeholder for async-loaded sections
+            // A vacant dwelling, awaiting the arrival of asynchronous tidings
             var containersSection = new VerticalStackLayout { Spacing = 8 };
             var loanHistorySection = new VerticalStackLayout { Spacing = 8 };
 
@@ -121,7 +121,7 @@ namespace TagAndTrack.Pages
                 Content = root
             };
 
-            // Load containers and loan history asynchronously
+            // Summon the containers and loan chronicles by asynchronous means
             _ = LoadSpecimenDetailsAsync(specimen, containersSection, loanHistorySection);
         }
 
@@ -136,7 +136,7 @@ namespace TagAndTrack.Pages
 
             MainThread.BeginInvokeOnMainThread(() =>
             {
-                // --- Containers section ---
+                // --- The Containers, here assembled ---
                 var containerHeader = new Label
                 {
                     Text = "Containers:",
@@ -186,7 +186,7 @@ namespace TagAndTrack.Pages
                     }
                 }
 
-                // --- Loan history section ---
+                // --- The Chronicle of Loans past ---
                 var loanHeader = new Label
                 {
                     Text = "Loan History:",
@@ -304,7 +304,7 @@ namespace TagAndTrack.Pages
                 TextColor = CurrentTheme.Instance.Theme.Text
             };
 
-            // Page layout: info at top, list below. Let the CollectionView own scrolling.
+            // The page's arrangement: knowledge above, the list beneath. Let the CollectionView govern the scrolling.
             var root = new Grid
             {
                 RowSpacing = 16,
@@ -410,13 +410,13 @@ namespace TagAndTrack.Pages
 
             var now = DateTime.Now;
 
-            // Update in-memory state
+            // Amend the state held in memory
             loanItem.CheckinSpecimen(specimen.ID, now);
 
-            // Persist return date to join table
+            // Inscribe the date of return upon the joining table
             await DbService.CheckInLoanSpecimenAsync((int)loanItem.ID, (int)specimen.ID, now);
 
-            // Only mark specimen as present if it's not in any OTHER active loan
+            // Mark the specimen as present only if it dwelleth not within another active loan
             bool inOtherLoan = await DbService.IsSpecimenInAnyActiveLoanAsync((int)specimen.ID, (int)loanItem.ID);
             if (!inOtherLoan)
             {
@@ -424,7 +424,7 @@ namespace TagAndTrack.Pages
                 await DbService.UpdateSpecimenAsync((int)specimen.ID, true);
             }
 
-            // If all specimens are now returned, mark loan as returned
+            // Should every specimen now be returned, declare the loan fulfilled
             if (loanItem.Status)
             {
                 await DbService.UpdateLoanAsync((int)loanItem.ID, true);
@@ -447,16 +447,16 @@ namespace TagAndTrack.Pages
 
             var now = DateTime.Now;
 
-            // Check in each specimen that hasn't been returned yet for THIS loan
+            // Restore each specimen that hath not yet been returned for this very loan
             foreach (var specimen in loanItem.Specimens)
             {
                 if (loanItem.GetSpecimenReturnDate(specimen.ID) != null)
-                    continue; // already returned for this loan — skip
+                    continue; // already returned for this loan — make haste past it
 
                 loanItem.CheckinSpecimen(specimen.ID, now);
                 await DbService.CheckInLoanSpecimenAsync((int)loanItem.ID, (int)specimen.ID, now);
 
-                // Only mark specimen as present if not in another active loan
+                // Mark the specimen as present only if it resideth not in another active loan
                 bool inOtherLoan = await DbService.IsSpecimenInAnyActiveLoanAsync((int)specimen.ID, (int)loanItem.ID);
                 if (!inOtherLoan)
                 {
@@ -465,7 +465,7 @@ namespace TagAndTrack.Pages
                 }
             }
 
-            // Mark loan as returned
+            // Proclaim the loan returned in full
             await DbService.UpdateLoanAsync((int)loanItem.ID, true);
 
             await MainThread.InvokeOnMainThreadAsync(async () =>

--- a/code/TagAndTrack/TagAndTrack/Platforms/Windows/App.xaml.cs
+++ b/code/TagAndTrack/TagAndTrack/Platforms/Windows/App.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.UI.Xaml;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+// To learn more of WinUI, its project structure,
+// and further of our project templates, pray visit: http://aka.ms/winui-project-info.
 
 namespace TagAndTrack.WinUI
 {

--- a/code/TagAndTrack/TagAndTrack/TagAndTrack.csproj
+++ b/code/TagAndTrack/TagAndTrack/TagAndTrack.csproj
@@ -57,6 +57,12 @@
 		<CodesignProvision>Automatic</CodesignProvision>
 	</PropertyGroup>
 
+	<!-- Disable AOT in Debug to avoid missing mono-aot-cross binary (AOT is only needed for Release) -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios' and '$(Configuration)' == 'Debug'">
+		<RunAOTCompilation>false</RunAOTCompilation>
+		<MtouchInterpreter>all</MtouchInterpreter>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />


### PR DESCRIPTION
* [VERIFIED] Checkmarks for manual entry need recolored
* [VERIFIED] Replace stock buttons with tag & track buttons
* [VERIFIED] Modify date selector
* [NOTE VERIFIED but supposedly fixed] Look into why the datatable pages make 2 initially? (optional)
* [VERIFIED] prevent duplicate arctos IDs when creating an item
* [VERIFIED] Make the searchbar's background for the datatable adhere to the theme
* [VERIFIED] Fix container title saying "Loading..."


* [VERIFIED] Checking in items separately - store each return date for each item
* [VERIFIED] Edge case: check if a specimen has a return date in the loan when checking in a loan. If not, then that item is checked out in another loan and we don't want to check it in